### PR TITLE
Make sounds playable per notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Notification::make($title = null, $subtitle = null)
     ->showCancel(bool $value = true)
     // URL to the sound that the notification should make
     ->sound('https://url-to-a-sound-file')
+    // If `play_sound` is set to true in your config, every notification will play the default sound. You can disable the sound per notification here.
+    ->playSound(bool $value = true)
     // Whether to show the toasted popup notification
     ->displayToasted(bool $value = true)
     // Alias to invoke the displayToasted() with false

--- a/resources/js/components/NotificationsDropdown.vue
+++ b/resources/js/components/NotificationsDropdown.vue
@@ -134,7 +134,9 @@
                   })
                 }
 
-                this.playSound(notification.sound)
+                if(notification.play_sound) {
+                    this.playSound(notification.sound)
+                }
             },
             markAllAsRead: function () {
                 axios

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -25,6 +25,7 @@ class Notification implements NotificationContract, Arrayable
         $this
             ->showMarkAsRead()
             ->showCancel()
+            ->playSound()
             ->displayToasted()
             ->createdAt(Carbon::now());
     }

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -147,6 +147,12 @@ class Notification implements NotificationContract, Arrayable
         $this->notification['sound'] = $value;
         return $this;
     }
+    
+    public function playSound(bool $value = true): Notification
+    {
+        $this->notification['play_sound'] = $value;
+        return $this;
+    }
 
     public function displayToasted(bool $value = true): Notification
     {

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -31,10 +31,11 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(4, $notification);
+        $this->assertCount(5, $notification);
         $this->assertArrayHasKey('created_at', $notification);
         $this->assertArrayHasKey('show_mark_as_read', $notification);
         $this->assertArrayHasKey('show_cancel', $notification);
+        $this->assertArrayHasKey('play_sound', $notification);
         $this->assertTrue($notification['show_mark_as_read']);
         $this->assertTrue($notification['show_cancel']);
     }
@@ -52,7 +53,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(6, $notification);
         $this->assertArrayHasKey('title', $notification);
         $this->assertSame($title, $notification['title']);
     }
@@ -70,7 +71,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(6, $notification);
         $this->assertArrayHasKey('subtitle', $notification);
         $this->assertSame($subtitle, $notification['subtitle']);
     }
@@ -88,7 +89,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(6, $notification);
         $this->assertArrayHasKey('title', $notification);
         $this->assertSame($title, $notification['title']);
     }
@@ -106,7 +107,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(6, $notification);
         $this->assertArrayHasKey('subtitle', $notification);
         $this->assertSame($subtitle, $notification['subtitle']);
     }
@@ -124,7 +125,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(6, $notification);
+        $this->assertCount(7, $notification);
         $this->assertArrayHasKey('url', $notification);
         $this->assertArrayHasKey('external', $notification);
         $this->assertSame($link, $notification['url']);
@@ -144,7 +145,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(6, $notification);
+        $this->assertCount(7, $notification);
         $this->assertArrayHasKey('url', $notification);
         $this->assertArrayHasKey('external', $notification);
         $this->assertSame($link, $notification['url']);
@@ -165,7 +166,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(6, $notification);
         $this->assertArrayHasKey('route', $notification);
         $this->assertCount(2, $notification['route']);
         $this->assertCount(1, $notification['route']['params']);
@@ -188,7 +189,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(6, $notification);
         $this->assertArrayHasKey('route', $notification);
         $this->assertCount(2, $notification['route']);
         $this->assertCount(2, $notification['route']['params']);
@@ -260,7 +261,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(6, $notification);
         $this->assertArrayHasKey('level', $notification);
         $this->assertSame($level, $notification['level']);
     }
@@ -280,7 +281,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(6, $notification);
         $this->assertArrayHasKey('level', $notification);
         $this->assertNotSame($level, $notification['level']);
         $this->assertSame('info', $notification['level']);
@@ -351,7 +352,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(6, $notification);
         $this->assertArrayHasKey('icon', $notification);
         $this->assertSame($icon, $notification['icon']);
     }
@@ -364,7 +365,7 @@ class NotificationTest extends TestCase
         $notification = Notification::make()->toArray();
 
         $this->assertTrue(is_array($notification));
-        $this->assertCount(3, $notification);
+        $this->assertCount(5, $notification);
     }
 
     /**
@@ -387,7 +388,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(4, $notification);
+        $this->assertCount(5, $notification);
         $this->assertFalse($notification['show_mark_as_read']);
     }
 
@@ -402,7 +403,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(4, $notification);
+        $this->assertCount(5, $notification);
         $this->assertFalse($notification['show_cancel']);
     }
 
@@ -419,8 +420,39 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(4, $notification);
+        $this->assertCount(6, $notification);
         $this->assertSame($sound, $notification['sound']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_setting_play_sound_to_false()
+    {
+
+        $notification = Notification::make()->playSound(false);
+
+        $this->assertInstanceOf(Notification::class, $notification);
+
+        $notification = $notification->toArray();
+
+        $this->assertCount(5, $notification);
+        $this->assertFalse($notification['play_sound']);
+    }
+
+        /**
+     * @test
+     */
+    public function it_allows_setting_play_sound_to_true()
+    {
+        $notification = Notification::make()->playSound(true);
+
+        $this->assertInstanceOf(Notification::class, $notification);
+
+        $notification = $notification->toArray();
+
+        $this->assertCount(5, $notification);
+        $this->assertTrue($notification['play_sound']);
     }
 
     /**
@@ -434,7 +466,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(4, $notification);
+        $this->assertCount(5, $notification);
         $this->assertTrue($notification['display_toasted']);
     }
 
@@ -449,7 +481,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(4, $notification);
+        $this->assertCount(5, $notification);
         $this->assertFalse($notification['display_toasted']);
     }
 
@@ -459,7 +491,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(4, $notification);
+        $this->assertCount(6, $notification);
 
         $this->assertArrayHasKey('route', $notification);
 
@@ -476,7 +508,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(4, $notification);
+        $this->assertCount(6, $notification);
 
         $this->assertArrayHasKey('route', $notification);
 
@@ -494,7 +526,7 @@ class NotificationTest extends TestCase
 
         $notification = $notification->toArray();
 
-        $this->assertCount(5, $notification);
+        $this->assertCount(7, $notification);
 
         $this->assertArrayHasKey('title', $notification);
         $this->assertArrayHasKey('level', $notification);

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -440,7 +440,7 @@ class NotificationTest extends TestCase
         $this->assertFalse($notification['play_sound']);
     }
 
-        /**
+    /**
      * @test
      */
     public function it_allows_setting_play_sound_to_true()


### PR DESCRIPTION
The current implementation of the notification sounds means that enabling it will play the sound for every notification.

This PR builds upon the existing notification sounds by allowing you to disable them per notification.

If you disable the play_sound in the config, it will still disable all sounds so there are no side effects.